### PR TITLE
商品詳細表示機能実装

### DIFF
--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -17,6 +17,10 @@ class ListingsController < ApplicationController
     end
   end
 
+  def show
+    
+  end
+
   private
 
   def listing_params

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -18,7 +18,7 @@ class ListingsController < ApplicationController
   end
 
   def show
-    
+    @listing = Listing.find(params[:id])
   end
 
   private

--- a/app/views/listings/index.html.erb
+++ b/app/views/listings/index.html.erb
@@ -127,7 +127,7 @@
     <ul class='item-lists'>
     <% @listings.each do |listing| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to listing_path(listing.id), method: :get do %>
         <div class='item-img-content'>
           <%= image_tag listing.image, class: "item-img" %>
 

--- a/app/views/listings/show.html.erb
+++ b/app/views/listings/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @listing.product_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @listing.image, class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -16,54 +16,56 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @listing.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @listing.shipping_burden.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
+    <% if user_signed_in? && current_user.id == @listing.user.id %>
+      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <p class="or-text">or</p>
+      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <% end %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <% if user_signed_in? && current_user.id != @listing.user.id %>
+      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @listing.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @listing.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @listing.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @listing.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @listing.shipping_burden.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @listing.prefectures.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @listing.shipping_days.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/listings/show.html.erb
+++ b/app/views/listings/show.html.erb
@@ -100,9 +100,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @listing.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/listings/show.html.erb
+++ b/app/views/listings/show.html.erb
@@ -23,20 +23,16 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <% if user_signed_in? && current_user.id == @listing.user.id %>
       <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
       <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
     <% end %>
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
+
     <% if user_signed_in? && current_user.id != @listing.user.id %>
       <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <% end %>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
 
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= @listing.description %></span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "listings#index"
-  resources :listings, only: [:index, :new, :create]
+  resources :listings, only: [:index, :new, :create, :show]
 end


### PR DESCRIPTION
# What
商品詳細表示昨日の実装
# Why
詳細ページを表示させるため

ログインユーザーが自身の出品した商品のページに遷移する動画URL
https://gyazo.com/940145b98f3b2af9beb3279a0a13aaa1
ログイン状態の出品者以外のユーザーが、他者の出品した販売中商品の詳細ページへ遷移した動画URL
https://gyazo.com/deebbb999d708da28be8186e8a54f45b
ログアウト状態のユーザーが、商品詳細ページへ遷移した動画URL
https://gyazo.com/3c86b13cf5caf673933836373712a8fb