### PR TITLE
商品情報編集機能実装

### DIFF
--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -1,5 +1,8 @@
 class ListingsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
+  before_action :set_listing,        only: [:show, :edit, :update]
+  before_action :move_to_new,        only: :edit
+
   def index
     @listings = Listing.all.order('created_at DESC')
   end
@@ -18,15 +21,23 @@ class ListingsController < ApplicationController
   end
 
   def show
-    @listing = Listing.find(params[:id])
+    
   end
 
   def edit
-    @listing = Listing.find(params[:id])
+    if current_user.id == @listing.user.id
+      render :edit
+    else
+      redirect_to root_path
+    end
   end
 
   def update
-    
+    if @listing.update(listing_params)
+      redirect_to listing_path(@listing)
+    else
+      render :edit
+    end
   end
 
   private
@@ -35,5 +46,15 @@ class ListingsController < ApplicationController
     params.require(:listing).permit(:image, :product_name, :description, :category_id, :status_id, :shipping_burden_id,
                                     :prefectures_id, :shipping_days_id, :price)
           .merge(user_id: current_user.id)
+  end
+
+  def set_listing
+    @listing = Listing.find(params[:id])
+  end
+
+  def move_to_new
+    unless user_signed_in?
+      redirect_to action: :new
+    end
   end
 end

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -1,7 +1,8 @@
 class ListingsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
   before_action :set_listing,        only: [:show, :edit, :update]
-  before_action :move_to_new,        only: :edit
+  before_action :move_to_new,        only: [:edit, :update]
+  before_action :move_to_index,      only: [:edit, :update]
 
   def index
     @listings = Listing.all.order('created_at DESC')
@@ -55,6 +56,12 @@ class ListingsController < ApplicationController
   def move_to_new
     unless user_signed_in?
       redirect_to action: :new
+    end
+  end
+
+  def move_to_index
+    unless current_user.id != @listing.user.id
+      redirect_to action: :index
     end
   end
 end

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -21,6 +21,14 @@ class ListingsController < ApplicationController
     @listing = Listing.find(params[:id])
   end
 
+  def edit
+    @listing = Listing.find(params[:id])
+  end
+
+  def update
+    
+  end
+
   private
 
   def listing_params

--- a/app/views/listings/edit.html.erb
+++ b/app/views/listings/edit.html.erb
@@ -9,9 +9,7 @@ app/assets/stylesheets/items/new.css %>
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @listing, url: listing_path, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%= render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 出品画像 %>
     <div class="img-upload">

--- a/app/views/listings/edit.html.erb
+++ b/app/views/listings/edit.html.erb
@@ -7,10 +7,10 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @listing, url: listing_path, local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
+    <%= render 'shared/error_messages', model: f.object %>
     <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 出品画像 %>
@@ -23,7 +23,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /出品画像 %>
@@ -33,13 +33,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :product_name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +52,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:status_id, Status.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +73,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_burden_id, ShippingBurden.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefectures_id, Prefectures.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_days_id, ShippingDays.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +101,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -141,7 +141,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', listing_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/listings/show.html.erb
+++ b/app/views/listings/show.html.erb
@@ -24,7 +24,7 @@
     </div>
 
     <% if user_signed_in? && current_user.id == @listing.user.id %>
-      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <%= link_to "商品の編集", edit_listing_path(@listing.id), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
       <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "listings#index"
-  resources :listings, only: [:index, :new, :create, :show]
+  resources :listings, only: [:index, :new, :create, :show, :edit, :update]
 end


### PR DESCRIPTION
# What
商品情報編集機能の実装
# Why
編集ページを作成するため

ログイン状態の出品者は、商品情報編集ページに遷移できる動画URL
https://gyazo.com/937ca910e158e1e9b675f12bb3b82d93
正しく情報を記入すると、商品の情報を編集できる動画URL
https://gyazo.com/471684d3fc095f3651e5866287a1780f
入力に問題のある状態では商品の情報は編集できず、エラーメッセージが出力される動画URL
https://gyazo.com/14697ec7621a86f83b6082b85feeed78
何も編集せずに更新をしても画像無しの商品にならない動画URL
https://gyazo.com/a1e2a1dd1a645401262737163a74cc89
ログインユーザーでもURLを直接入力して出品していない商品の情報編集ページへ遷移しようとすると、トップページに遷移する動画URL:https://gyazo.com/05e799e011946bf22aad6df75d7708e0
ログアウトユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移する動画URL
https://gyazo.com/6b6f72522cf13e058d57d94439b8f23d
商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画URL
https://gyazo.com/c0377fd71801a0fc017934b8f5cc8dc4